### PR TITLE
samples(storage) add samples and test cases for objects soft delete

### DIFF
--- a/storage/api/Storage.Samples.Tests/ListSoftDeletedObjectsTest.cs
+++ b/storage/api/Storage.Samples.Tests/ListSoftDeletedObjectsTest.cs
@@ -1,0 +1,47 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using System;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class ListSoftDeletedObjectsTest
+{
+    private readonly StorageFixture _fixture;
+
+    public ListSoftDeletedObjectsTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void ListSoftDeletedObjects()
+    {
+        ListSoftDeletedObjectsSample listSoftDeletedObjects = new ListSoftDeletedObjectsSample();
+        UploadObjectFromMemorySample uploadObjectFromMemory = new UploadObjectFromMemorySample();
+        var bucketName = _fixture.GenerateBucketName();
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: false, registerForDeletion: true);
+        var objectName = Guid.NewGuid().ToString();
+        var objectContents = Guid.NewGuid().ToString();
+        var testObjectName = Guid.NewGuid().ToString();
+        var testObjectContents = Guid.NewGuid().ToString();
+        uploadObjectFromMemory.UploadObjectFromMemory(bucketName, objectName, objectContents);
+        uploadObjectFromMemory.UploadObjectFromMemory(bucketName, testObjectName, testObjectContents);
+        _fixture.Client.DeleteObject(bucketName, objectName);
+        _fixture.Client.DeleteObject(bucketName, testObjectName);
+        var objects = listSoftDeletedObjects.ListSoftDeletedObjects(bucketName);
+        Assert.Contains(objects, c => c.Name == objectName);
+        Assert.Contains(objects, c => c.Name == testObjectName);
+    }
+}

--- a/storage/api/Storage.Samples/ListSoftDeletedObjects.cs
+++ b/storage/api/Storage.Samples/ListSoftDeletedObjects.cs
@@ -1,0 +1,39 @@
+// Copyright 2025 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_list_soft_deleted_objects]
+
+using Google.Cloud.Storage.V1;
+using System;
+using System.Collections.Generic;
+
+public class ListSoftDeletedObjectsSample
+{
+    /// <summary>
+    /// List soft deleted objects.
+    /// </summary>
+    /// <param name="bucketName">The name of the bucket to list soft-deleted objects from.</param>
+    public IEnumerable<Google.Apis.Storage.v1.Data.Object> ListSoftDeletedObjects(string bucketName = "your-unique-bucket-name")
+    {
+        var storage = StorageClient.Create();
+        var objects = storage.ListObjects(bucketName, null, new ListObjectsOptions { SoftDeletedOnly = true });
+        Console.WriteLine("Soft Deleted Objects are as follows:");
+        foreach (var obj in objects)
+        {
+            Console.WriteLine(obj.Name);
+        }
+        return objects;
+    }
+}
+// [END storage_list_soft_deleted_objects]


### PR DESCRIPTION
Add samples and test cases for objects soft delete as follows:-

- [ ] storage_disable_soft_delete
- [ ] storage_get_soft_delete_policy
- [ ] storage_set_soft_delete_policy
- [ ] storage_list_soft_deleted_objects
- [ ] storage_list_soft_deleted_object_versions
- [ ] storage_restore_object