### PR TITLE
Samples(storage control): add samples for Anywhere Cache

### DIFF
--- a/storagecontrol/api/StorageControl.Samples.Tests/StorageControl.Samples.Tests.csproj
+++ b/storagecontrol/api/StorageControl.Samples.Tests/StorageControl.Samples.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StorageControl.Samples\StorageControl.Samples.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/storagecontrol/api/StorageControl.Samples.Tests/StorageFixture.cs
+++ b/storagecontrol/api/StorageControl.Samples.Tests/StorageFixture.cs
@@ -1,0 +1,115 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.ResourceNames;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Storage.v1.Data;
+using Google.Cloud.Storage.Control.V2;
+using Google.Cloud.Storage.V1;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+[CollectionDefinition(nameof(StorageFixture))]
+public class StorageFixture : IDisposable, ICollectionFixture<StorageFixture>
+{
+    public string ProjectId { get; }
+    public string LocationId { get; } = "global";
+    public IList<string> TempBucketNames { get; } = [];
+    public string ServiceAccountEmail { get; } = "gcs-iam-acl-test@dotnet-docs-samples-tests.iam.gserviceaccount.com";
+    public StorageClient Client { get; }
+    public StorageControlClient ControlClient { get; }
+    public LocationName LocationName { get; }
+
+    public StorageFixture()
+    {
+        ProjectId = Environment.GetEnvironmentVariable("GOOGLE_PROJECT_ID");
+        if (string.IsNullOrWhiteSpace(ProjectId))
+        {
+            throw new Exception("You need to set the Environment variable 'GOOGLE_PROJECT_ID' with your Google Cloud Project's project id.");
+        }
+        LocationName = LocationName.FromProjectLocation(ProjectId, LocationId);
+        Client = StorageClient.Create();
+        ControlClient = StorageControlClient.Create();
+    }
+
+    /// <summary>
+    /// Creates a bucket.
+    /// </summary>
+    /// <returns>A bucket.</returns>
+    internal Bucket CreateBucket(string name, bool multiVersion, bool softDelete = false, bool registerForDeletion = true)
+    {
+        var bucket = Client.CreateBucket(ProjectId,
+            new Bucket
+            {
+                Name = name,
+                Versioning = new Bucket.VersioningData { Enabled = multiVersion },
+                // The minimum allowed for soft delete is 7 days.
+                SoftDeletePolicy = softDelete ? new Bucket.SoftDeletePolicyData { RetentionDurationSeconds = (int) TimeSpan.FromDays(7).TotalSeconds } : null,
+            });
+        SleepAfterBucketCreateUpdateDelete();
+        if (registerForDeletion)
+        {
+            TempBucketNames.Add(name);
+        }
+        return bucket;
+    }
+
+    /// <summary>
+    /// Generate the name of the bucket.
+    /// </summary>
+    /// <returns>The bucketName.</returns>
+    internal string GenerateBucketName() => Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Generates a new globally unique identifier (GUID).
+    /// </summary>
+    /// <returns>A new randomly generated GUID as string.</returns>
+    internal string GenerateGuid() => Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Bucket creation/update/deletion is rate-limited. To avoid making the tests flaky, we sleep after each operation.
+    /// </summary>
+    internal void SleepAfterBucketCreateUpdateDelete() => Thread.Sleep(2000);
+
+    internal string GetServiceAccountEmail()
+    {
+        var cred = GoogleCredential.GetApplicationDefault().UnderlyingCredential;
+        switch (cred)
+        {
+            case ServiceAccountCredential sac:
+                return sac.Id;
+            // TODO: We may well need to handle ComputeCredential for Kokoro.
+            default:
+                throw new InvalidOperationException($"Unable to retrieve service account email address for credential type {cred.GetType()}");
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var bucketName in TempBucketNames)
+        {
+            try
+            {
+                Client.DeleteBucket(bucketName, new DeleteBucketOptions { DeleteObjects = true });
+                SleepAfterBucketCreateUpdateDelete();
+            }
+            catch (Exception)
+            {
+                // Do nothing, we delete on a best effort basis.
+            }
+        }
+    }
+}

--- a/storagecontrol/api/StorageControl.Samples/CreateAnywhereCache.cs
+++ b/storagecontrol/api/StorageControl.Samples/CreateAnywhereCache.cs
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_control_create_anywhere_cache]
+
+using Google.Cloud.Storage.Control.V2;
+using Google.LongRunning;
+
+public class CreateAnywhereCacheSample
+{
+    /// <summary>Creates an Anywhere Cache</summary>
+    public void CreateAnywhereCache()
+    {
+        // Create client
+        StorageControlClient storageControlClient = StorageControlClient.Create();
+        // Initialize request argument(s)
+        string parent = "projects/[PROJECT]/buckets/[BUCKET]";
+        AnywhereCache anywhereCache = new AnywhereCache();
+        // Make the request
+        Operation<AnywhereCache, CreateAnywhereCacheMetadata> response = storageControlClient.CreateAnywhereCache(parent, anywhereCache);
+
+        // Poll until the returned long-running operation is complete
+        Operation<AnywhereCache, CreateAnywhereCacheMetadata> completedResponse = response.PollUntilCompleted();
+        // Retrieve the operation result
+        AnywhereCache result = completedResponse.Result;
+
+        // Or get the name of the operation
+        string operationName = response.Name;
+        // This name can be stored, then the long-running operation retrieved later by name
+        Operation<AnywhereCache, CreateAnywhereCacheMetadata> retrievedResponse = storageControlClient.PollOnceCreateAnywhereCache(operationName);
+        // Check if the retrieved long-running operation has completed
+        if (retrievedResponse.IsCompleted)
+        {
+            // If it has completed, then access the result
+            AnywhereCache retrievedResult = retrievedResponse.Result;
+        }
+    }
+}
+// [END storage_control_create_anywhere_cache]

--- a/storagecontrol/api/StorageControl.Samples/DisableAnywhereCache.cs
+++ b/storagecontrol/api/StorageControl.Samples/DisableAnywhereCache.cs
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_control_disable_anywhere_cache]
+
+using Google.Cloud.Storage.Control.V2;
+
+public class DisableAnywhereCacheSample
+{
+    /// <summary>Disable an Anywhere Cache</summary>
+    public void DisableAnywhereCache()
+    {
+        // Create client
+        StorageControlClient storageControlClient = StorageControlClient.Create();
+        // Initialize request argument(s)
+        string name = "projects/[PROJECT]/buckets/[BUCKET]/anywhereCaches/[ANYWHERE_CACHE]";
+        // Make the request
+        AnywhereCache response = storageControlClient.DisableAnywhereCache(name);
+    }
+}
+// [END storage_control_disable_anywhere_cache]

--- a/storagecontrol/api/StorageControl.Samples/GetAnywhereCache.cs
+++ b/storagecontrol/api/StorageControl.Samples/GetAnywhereCache.cs
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_control_get_anywhere_cache]
+
+using Google.Cloud.Storage.Control.V2;
+
+public class GetAnywhereCacheSample
+{
+    /// <summary>Get an Anywhere Cache</summary>
+    public void GetAnywhereCache()
+    {
+        // Create client
+        StorageControlClient storageControlClient = StorageControlClient.Create();
+        // Initialize request argument(s)
+        string name = "projects/[PROJECT]/buckets/[BUCKET]/anywhereCaches/[ANYWHERE_CACHE]";
+        // Make the request
+        AnywhereCache response = storageControlClient.GetAnywhereCache(name);
+    }
+}
+// [END storage_control_get_anywhere_cache]

--- a/storagecontrol/api/StorageControl.Samples/GetAnywhereCache.cs
+++ b/storagecontrol/api/StorageControl.Samples/GetAnywhereCache.cs
@@ -15,18 +15,19 @@
 // [START storage_control_get_anywhere_cache]
 
 using Google.Cloud.Storage.Control.V2;
+using System;
 
 public class GetAnywhereCacheSample
 {
     /// <summary>Get an Anywhere Cache</summary>
-    public void GetAnywhereCache()
+    /// <param name="cacheName">The name of Anywhere Cache in the format of projects/[PROJECT]/buckets/[BUCKET]/anywhereCaches/[ANYWHERE_CACHE]</param>
+    public void GetAnywhereCache(string cacheName = "projects/[PROJECT]/buckets/[BUCKET]/anywhereCaches/[ANYWHERE_CACHE]")
     {
         // Create client
         StorageControlClient storageControlClient = StorageControlClient.Create();
-        // Initialize request argument(s)
-        string name = "projects/[PROJECT]/buckets/[BUCKET]/anywhereCaches/[ANYWHERE_CACHE]";
         // Make the request
-        AnywhereCache response = storageControlClient.GetAnywhereCache(name);
+        AnywhereCache response = storageControlClient.GetAnywhereCache(cacheName);
+        Console.WriteLine($"Got anywhere cache {response.Name}");
     }
 }
 // [END storage_control_get_anywhere_cache]

--- a/storagecontrol/api/StorageControl.Samples/ListAnywhereCache.cs
+++ b/storagecontrol/api/StorageControl.Samples/ListAnywhereCache.cs
@@ -1,0 +1,66 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_control_list_anywhere_cache]
+
+using Google.Api.Gax;
+using Google.Cloud.Storage.Control.V2;
+using System;
+
+public class ListAnywhereCachesSample
+{
+    /// <summary>Lists an Anywhere Caches</summary>
+    public void ListAnywhereCaches()
+    {
+        // Create client
+        StorageControlClient storageControlClient = StorageControlClient.Create();
+        // Initialize request argument(s)
+        string parent = "projects/[PROJECT]/buckets/[BUCKET]";
+        // Make the request
+        PagedEnumerable<ListAnywhereCachesResponse, AnywhereCache> response = storageControlClient.ListAnywhereCaches(parent);
+
+        // Iterate over all response items, lazily performing RPCs as required
+        foreach (AnywhereCache item in response)
+        {
+            // Do something with each item
+            Console.WriteLine(item);
+        }
+
+        // Or iterate over pages (of server-defined size), performing one RPC per page
+        foreach (ListAnywhereCachesResponse page in response.AsRawResponses())
+        {
+            // Do something with each page of items
+            Console.WriteLine("A page of results:");
+            foreach (AnywhereCache item in page)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+        }
+
+        // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+        int pageSize = 10;
+        Page<AnywhereCache> singlePage = response.ReadPage(pageSize);
+        // Do something with the page of items
+        Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+        foreach (AnywhereCache item in singlePage)
+        {
+            // Do something with each item
+            Console.WriteLine(item);
+        }
+        // Store the pageToken, for when the next page is required.
+        string nextPageToken = singlePage.NextPageToken;
+    }
+}
+// [END storage_control_list_anywhere_cache]

--- a/storagecontrol/api/StorageControl.Samples/PauseAnywhereCache.cs
+++ b/storagecontrol/api/StorageControl.Samples/PauseAnywhereCache.cs
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_control_pause_anywhere_cache]
+
+using Google.Cloud.Storage.Control.V2;
+
+public class PauseAnywhereCacheSample
+{
+    /// <summary>Pause an Anywhere Cache</summary>
+    public void PauseAnywhereCache()
+    {
+        // Create client
+        StorageControlClient storageControlClient = StorageControlClient.Create();
+        // Initialize request argument(s)
+        string name = "projects/[PROJECT]/buckets/[BUCKET]/anywhereCaches/[ANYWHERE_CACHE]";
+        // Make the request
+        AnywhereCache response = storageControlClient.PauseAnywhereCache(name);
+    }
+}
+// [END storage_control_pause_anywhere_cache]

--- a/storagecontrol/api/StorageControl.Samples/ResumeAnywhereCache.cs
+++ b/storagecontrol/api/StorageControl.Samples/ResumeAnywhereCache.cs
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_control_resume_anywhere_cache]
+
+using Google.Cloud.Storage.Control.V2;
+
+public class ResumeAnywhereCacheSample
+{
+    /// <summary>Resume an Anywhere Cache</summary>
+    public void ResumeAnywhereCache()
+    {
+        // Create client
+        StorageControlClient storageControlClient = StorageControlClient.Create();
+        // Initialize request argument(s)
+        string name = "projects/[PROJECT]/buckets/[BUCKET]/anywhereCaches/[ANYWHERE_CACHE]";
+        // Make the request
+        AnywhereCache response = storageControlClient.ResumeAnywhereCache(name);
+    }
+}
+// [END storage_control_resume_anywhere_cache]

--- a/storagecontrol/api/StorageControl.Samples/StorageControl.Samples.csproj
+++ b/storagecontrol/api/StorageControl.Samples/StorageControl.Samples.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.13.0" />
+    <PackageReference Include="Google.Cloud.Storage.Control.V2" Version="1.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/storagecontrol/api/StorageControl.Samples/UpdateAnywhereCache.cs
+++ b/storagecontrol/api/StorageControl.Samples/UpdateAnywhereCache.cs
@@ -1,0 +1,51 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_control_update_anywhere_cache]
+
+using Google.Cloud.Storage.Control.V2;
+using Google.LongRunning;
+using Google.Protobuf.WellKnownTypes;
+
+public class UpdateAnywhereCacheSample
+{
+    /// <summary>Update an Anywhere Cache</summary>
+    public void UpdateAnywhereCache()
+    {
+        // Create client
+        StorageControlClient storageControlClient = StorageControlClient.Create();
+        // Initialize request argument(s)
+        AnywhereCache anywhereCache = new AnywhereCache();
+        FieldMask updateMask = new FieldMask();
+        // Make the request
+        Operation<AnywhereCache, UpdateAnywhereCacheMetadata> response = storageControlClient.UpdateAnywhereCache(anywhereCache, updateMask);
+
+        // Poll until the returned long-running operation is complete
+        Operation<AnywhereCache, UpdateAnywhereCacheMetadata> completedResponse = response.PollUntilCompleted();
+        // Retrieve the operation result
+        AnywhereCache result = completedResponse.Result;
+
+        // Or get the name of the operation
+        string operationName = response.Name;
+        // This name can be stored, then the long-running operation retrieved later by name
+        Operation<AnywhereCache, UpdateAnywhereCacheMetadata> retrievedResponse = storageControlClient.PollOnceUpdateAnywhereCache(operationName);
+        // Check if the retrieved long-running operation has completed
+        if (retrievedResponse.IsCompleted)
+        {
+            // If it has completed, then access the result
+            AnywhereCache retrievedResult = retrievedResponse.Result;
+        }
+    }
+}
+// [END storage_control_update_anywhere_cache]

--- a/storagecontrol/api/StorageControl.sln
+++ b/storagecontrol/api/StorageControl.sln
@@ -1,0 +1,50 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35303.130
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StorageControl.Samples", "StorageControl.Samples\StorageControl.Samples.csproj", "{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StorageControl.Samples.Tests", "StorageControl.Samples.Tests\StorageControl.Samples.Tests.csproj", "{2BB74746-319D-465B-AAD5-C4430322501E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|x64.Build.0 = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|x86.Build.0 = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|x64.ActiveCfg = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|x64.Build.0 = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|x86.ActiveCfg = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|x86.Build.0 = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|x64.Build.0 = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|x86.Build.0 = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|x64.ActiveCfg = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|x64.Build.0 = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|x86.ActiveCfg = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FD4D03FF-F99F-48B7-92EA-B9A73DF78693}
+	EndGlobalSection
+EndGlobal

--- a/storagecontrol/api/runTests.ps1
+++ b/storagecontrol/api/runTests.ps1
@@ -1,0 +1,16 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+dotnet restore --force
+dotnet test --no-restore --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }


### PR DESCRIPTION
This internal PR adds sample code for the anywhere cache feature, allowing users to:

- [ ] Create anywhere cache
- [ ] Get anywhere cache
- [ ] List anywhere cache
- [ ] Update anywhere cache
- [ ] Pause anywhere cache
- [ ] Disable anywhere cache
- [ ] Resume anywhere cache

Note


 Tests are not included in the PR because it takes too long to complete.