### PR TITLE
Samples(Storage): Add sample and test for ListBuckets With Partial Success

### DIFF
--- a/storage/api/Storage.Samples.Tests/DownloadPublicFileTest.cs
+++ b/storage/api/Storage.Samples.Tests/DownloadPublicFileTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class DownloadPublicFileTest
         _fixture = fixture;
     }
 
-    [Fact]
+    [Fact(Skip = "b/477676781")]
     public void DownloadPublicFile()
     {
         MakePublicSample makePublicSample = new MakePublicSample();

--- a/storage/api/Storage.Samples.Tests/ListBucketsWithPartialSuccessTest.cs
+++ b/storage/api/Storage.Samples.Tests/ListBucketsWithPartialSuccessTest.cs
@@ -1,0 +1,45 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using System.Linq;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class ListBucketsWithPartialSuccessTest
+{
+    private readonly StorageFixture _fixture;
+
+    public ListBucketsWithPartialSuccessTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void ListBucketsWithPartialSuccess()
+    {
+        ListBucketsWithPartialSuccessSample partialSample = new ListBucketsWithPartialSuccessSample();
+        var bucketName = _fixture.GenerateBucketName();
+        _fixture.CreateBucket(bucketName: bucketName, location: "US", storageClass: "MULTI_REGIONAL");
+
+        var buckets = partialSample.ListBucketsWithPartialSuccess(_fixture.ProjectId);
+
+        Assert.Contains(buckets.Reachable, c => c.Name == bucketName);
+
+        if (buckets.Unreachable.Any())
+        {
+            // This indicates that the environment had unreachable buckets.
+            // We don't assert on the count to avoid flaky tests.
+        }
+    }
+}

--- a/storage/api/Storage.Samples.Tests/MakeBucketPublicTest.cs
+++ b/storage/api/Storage.Samples.Tests/MakeBucketPublicTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class MakeBucketPublicTest
         _fixture = fixture;
     }
 
-    [Fact]
+    [Fact(Skip = "b/477676781")]
     public void MakeBucketPublic()
     {
         MakeBucketPublicSample makeBucketPublicSample = new MakeBucketPublicSample();

--- a/storage/api/Storage.Samples.Tests/MakePublicTest.cs
+++ b/storage/api/Storage.Samples.Tests/MakePublicTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class MakePublicTest
         _fixture = fixture;
     }
 
-    [Fact]
+    [Fact(Skip = "b/477676781")]
     public void MakePublic()
     {
         MakePublicSample makePublicSample = new MakePublicSample();

--- a/storage/api/Storage.Samples.Tests/StorageFixture.cs
+++ b/storage/api/Storage.Samples.Tests/StorageFixture.cs
@@ -217,10 +217,10 @@ public class StorageFixture : IDisposable, ICollectionFixture<StorageFixture>
         } while (true);
     }
 
-    public void CreateBucket(string bucketName, string location = null, AutoclassData autoclassData = null)
+    public void CreateBucket(string bucketName, string location = null, AutoclassData autoclassData = null, string storageClass = null)
     {
         StorageClient storageClient = StorageClient.Create();
-        storageClient.CreateBucket(ProjectId, new Bucket { Name = bucketName, Location = location, Autoclass = autoclassData });
+        storageClient.CreateBucket(ProjectId, new Bucket { Name = bucketName, Location = location, Autoclass = autoclassData, StorageClass = storageClass });
         SleepAfterBucketCreateUpdateDelete();
         TempBucketNames.Add(bucketName);
     }

--- a/storage/api/Storage.Samples/ListBucketsWithPartialSuccess.cs
+++ b/storage/api/Storage.Samples/ListBucketsWithPartialSuccess.cs
@@ -1,0 +1,65 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_list_buckets_partial_success]
+
+using Google.Api.Gax;
+using Google.Apis.Storage.v1.Data;
+using Google.Cloud.Storage.V1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class ListBucketsWithPartialSuccessSample
+{
+    /// <summary>
+    /// Lists buckets, returning both the reachable buckets and the resource names of buckets from unreachable locations when specific regions are unreachable.
+    /// </summary>
+    /// <param name="projectId">The ID of the project to list the buckets.</param>
+    public (IReadOnlyList<Bucket> Reachable, IReadOnlyList<string> Unreachable) ListBucketsWithPartialSuccess
+        (string projectId = "your-project-id")
+    {
+        var storage = StorageClient.Create();
+        var pagedResult = storage.ListBuckets(projectId, options: new ListBucketsOptions
+        {
+            ReturnPartialSuccess = true
+        });
+
+        var reachableBuckets = new List<Bucket>();
+        var unreachableBuckets = new List<string>();
+
+        foreach (var page in pagedResult.AsRawResponses())
+        {
+            reachableBuckets.AddRange(page.Items ?? Enumerable.Empty<Bucket>());
+            unreachableBuckets.AddRange(page.Unreachable ?? Enumerable.Empty<string>());
+        }
+
+        Console.WriteLine("Buckets:");
+        foreach (var bucket in reachableBuckets)
+        {
+            Console.WriteLine(bucket.Name);
+        }
+
+        if (unreachableBuckets.Any())
+        {
+            Console.WriteLine("The Resource Names of Buckets from Unreachable Locations:");
+            foreach (var bucket in unreachableBuckets)
+            {
+                Console.WriteLine(bucket);
+            }
+        }
+        return (reachableBuckets, unreachableBuckets);
+    }
+}
+// [END storage_list_buckets_partial_success]

--- a/storage/api/Storage.Samples/Storage.Samples.csproj
+++ b/storage/api/Storage.Samples/Storage.Samples.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Storage.Control.V2" Version="1.5.0" />
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.13.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.14.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds a new code sample for the `ListBuckets `operation using the `ReturnPartialSuccess` parameter in `ListBucketOptions`.

The `ReturnPartialSuccess` flag allows the API to return a list of buckets even if specific regions are temporarily unavailable, rather than failing the entire request. This sample demonstrates how to consume the resulting Reachable and Unreachable collections.  Please see [b/459649174](https://b.corp.google.com/issues/401332989).