### PR TITLE
fix(storage): resolve race condition in compose object test

### DIFF
--- a/storage/api/Storage.Samples.Tests/ChangeDefaultStorageClassTest.cs
+++ b/storage/api/Storage.Samples.Tests/ChangeDefaultStorageClassTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,11 +30,14 @@ public class ChangeDefaultStorageClassTest
     {
         ChangeDefaultStorageClassSample changeDefaultStorageClassSample = new ChangeDefaultStorageClassSample();
 
+        var bucketName = _fixture.GenerateBucketName();
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: false, registerForDeletion: true);
+
         // Change storage class to Coldline
-        var bucket = changeDefaultStorageClassSample.ChangeDefaultStorageClass(_fixture.BucketNameGeneric, StorageClasses.Coldline);
+        var bucket = changeDefaultStorageClassSample.ChangeDefaultStorageClass(bucketName, StorageClasses.Coldline);
         Assert.Equal(StorageClasses.Coldline, bucket.StorageClass);
 
         // Change it back to standard
-        changeDefaultStorageClassSample.ChangeDefaultStorageClass(_fixture.BucketNameGeneric, StorageClasses.Standard);
+        changeDefaultStorageClassSample.ChangeDefaultStorageClass(bucketName, StorageClasses.Standard);
     }
 }


### PR DESCRIPTION
This PR provides fix to the [issue](https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/2038).
The flake occurred because `ChangeDefaultStorageClassTest` was changing the storage class of the shared bucket `BucketNameGeneric` to `COLDLINE`. When `ComposeObjectTest` ran concurrently, it failed with a `BadRequest` because it attempted to compose objects with mixed storage classes (`Standard` vs `Coldline`).
This change has removed a shared bucket `BucketNameGeneric` used in `ChangeDefaultStorageClassTest` to prevent modifying the default storage class of the shared `BucketNameGeneric ` bucket, eliminating
test flakiness and mixed-storage-class compose errors in `ComposeObjectTest`